### PR TITLE
add secondary api to obtain dollar value

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -8,7 +8,12 @@ const Result = lazy(() => import("./Result"));
 function App() {
   const [income, setIncome] = useState(4000);
   const [showResults, setShowResults] = useState(false);
-  const [usd, setUsd] = useState(DEFAULT_USD_VALUE);
+  const [usd, setUsd] = useState(
+    {
+      valor: DEFAULT_USD_VALUE,
+      origin: 'default',
+    }
+  );
 
   useEffect(() => {
     const queryParams = new URLSearchParams(window.location.search);

--- a/src/components/Assumptions.jsx
+++ b/src/components/Assumptions.jsx
@@ -3,13 +3,24 @@ import { formatAmount } from "../core/numbers";
 
 export default function Assumptions({ assumptions }) {
   const { usd, bankFee } = assumptions;
+
+  const getUsdDetails = () => {
+    if (usd.origin === 'SII') {
+      return  <a href="https://www.sii.cl/valores_y_fechas/dolar/dolar2021.htm" target="_blank" rel="noreferrer">valor dólar hoy según SII</a>
+    } else if (usd.origin === 'SBIF') {
+      return <span>Valor entregado por <a href="https://www.sbif.cl" target="_blank" rel="noreferrer">CMF Bancos</a></span>
+    } else {
+      return 'Valor promedio del dólar durante el año 2022'
+    }
+  }
+
   return (
     <>
       <h2>Supuestos para el cálculo:</h2>
       <ul>
         <li>
-          Valor Dólar: <code>{formatAmount(usd)}</code>{" "}
-          (<a href="https://www.sii.cl/valores_y_fechas/dolar/dolar2021.htm" target="_blank" rel="noreferrer">valor dólar hoy según SII</a>)
+          Valor Dólar: <code>{formatAmount(usd.value)}</code>{" "}
+          ({getUsdDetails()})
         </li>
         <li>
           Te pagan en dólares, y te transfieren mediante{" "}

--- a/src/components/Details.jsx
+++ b/src/components/Details.jsx
@@ -100,7 +100,7 @@ export default function Details({ takeHome, takeHomePartial }) {
         </p>
         <p>
           Tu <strong>ingreso bruto anual</strong> en pesos chilenos es
-          <code>{formatAmount(sueldoAnual)}</code> (valor dólar = <code>{formatAmount(usd)}</code>)
+          <code>{formatAmount(sueldoAnual)}</code> (valor dólar = <code>{formatAmount(usd.value)}</code>)
         </p>
         <Detail
           retention={retencion}

--- a/src/core/calculator.js
+++ b/src/core/calculator.js
@@ -7,7 +7,7 @@ const { RETENCION, COBERTURA_PARCIAL } = obtenerConfiguracion();
 const BANK_FEE = 20; // usd
 
 export function getTakeHomeSalary(usdMonthlyIncome, usdToClp) {
-  const clpMonthlyIncome = (usdMonthlyIncome - BANK_FEE) * usdToClp;
+  const clpMonthlyIncome = (usdMonthlyIncome - BANK_FEE) * usdToClp.value;
   const taxes = calcular(clpMonthlyIncome);
   const { deuda: debt, retencion } = taxes;
   const takeHome = 12 * clpMonthlyIncome - retencion - debt;
@@ -26,7 +26,7 @@ export function getTakeHomeSalary(usdMonthlyIncome, usdToClp) {
 }
 
 export function getTakeHomeSalaryPartial(usdMonthlyIncome, usdToClp) {
-  const clpMonthlyIncome = usdMonthlyIncome * usdToClp;
+  const clpMonthlyIncome = usdMonthlyIncome * usdToClp.value;
   const taxes = calcular(clpMonthlyIncome);
   const { deudaModalidadParcial: debt, retencion } = taxes;
   const takeHome = 12 * clpMonthlyIncome - retencion - debt;


### PR DESCRIPTION
- Se incorpora como API secundaria la entregada por la Comisión para el Mercado Financiero ([Documentación](https://api.sbif.cl/documentacion/index.html))
- Se adapta el mensaje mostrado en los supuestos según el valor mostrado (api principal, secundaria o valor por defecto).

